### PR TITLE
Merge meta dictionary to root of body 

### DIFF
--- a/lib/src/insightops_dart_base.dart
+++ b/lib/src/insightops_dart_base.dart
@@ -93,11 +93,13 @@ class InsightOpsLogger {
     if (record.error != null) {
       body['error'] = record.error.toString();
     }
+
     final meta = await _getMeta();
-    if (meta?.isNotEmpty == true) {
-      body['meta'] = meta;
-    }
-    return body;
+    assert((meta?.isEmpty ?? true) ||
+        body.keys.toSet().intersection(meta.keys.toSet()).isEmpty);
+    meta?.removeWhere((key, _) => body.containsKey(key));
+
+    return {...body, ...?meta};
   }
 
   Duration _currentTimeout = _initialTimeout;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: insightops_dart
 description: Unofficial wrapper for using Rapid7 insightOps logs (former LogEntries) with Dart.
-version: 0.0.6
+version: 0.1.0
 homepage: https://github.com/ookami-kb/insightops_dart
 author: Kirill Bubochkin <ookami.kb@gmail.com>
 

--- a/test/insightops_dart_test.dart
+++ b/test/insightops_dart_test.dart
@@ -39,7 +39,10 @@ void main() {
     Logger.root.onRecord.listen(InsightOpsLogger(
       _url,
       post: testPostHandler,
-      getMeta: () async => {'deviceId': 'ID'},
+      getMeta: () async => {
+        'meta': {'deviceId': 'ID'},
+        'module': 'flutter'
+      },
     ));
 
     logger.info('message');
@@ -47,6 +50,7 @@ void main() {
     await Future.delayed(Duration(seconds: 1));
 
     expect(json.decode(sentMessages.first)['meta']['deviceId'], 'ID');
+    expect(json.decode(sentMessages.first)['module'], 'flutter');
   });
 
   test('retries after timeout on error', () async {


### PR DESCRIPTION
Merging the meta dictionary on top-level of the body dictionary allows for more structural freedom of the constructed logs. That makes it easier to be consistent with existing projects that log to InsightOps and re-use saved queries across multiple log sets / projects.

In case of conflicts, the proposed implementation gives precendence to the body's values.