### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.0
-- :tv: Update minimum Dart version to `3.2.0`
-- :tv: Updated plugin dependencies
+- :tv: Update minimum Dart version to `3.0.0`
+- :tv: Update minimum `http` version to `1.0.0`
 
 ## 0.2.0
 - :cop: Migrate to nullsafety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+- :tv: Update minimum Dart version to `3.2.0`
+- :tv: Updated plugin dependencies
+
 ## 0.2.0
 - :cop: Migrate to nullsafety
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ^2.11.0
-  http: ^1.2.1
+  http: ^1.2.0
   logging: ^1.2.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,13 +4,13 @@ version: 0.3.0
 homepage: https://github.com/ookami-kb/insightops_dart
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.0.0
 
 dependencies:
-  async: ^2.11.0
-  http: ^1.2.0
-  logging: ^1.2.0
+  async: ^2.5.0
+  http: ^1.0.0
+  logging: ^1.0.0
 
 dev_dependencies:
-  mews_pedantic: ^0.26.0
-  test: ^1.25.4
+  mews_pedantic: ^0.1.2
+  test: ^1.16.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: insightops_dart
 description: Unofficial wrapper for using Rapid7 insightOps logs (former LogEntries) with Dart.
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/ookami-kb/insightops_dart
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: ^3.2.0
 
 dependencies:
-  async: ^2.5.0
-  http: ^0.13.0
-  logging: ^1.0.0
+  async: ^2.11.0
+  http: ^1.2.1
+  logging: ^1.2.0
 
 dev_dependencies:
-  mews_pedantic: ^0.1.2
-  test: ^1.16.5
+  mews_pedantic: ^0.26.0
+  test: ^1.25.4


### PR DESCRIPTION
## 0.3.0
- :tv: Update minimum Dart version to `3.0.0`
- :tv: Updated plugin dependencies

@ookami-kb this allows us to continue using the plugin since other plugins are not compatible with the current version (`http: ^1.0.0` required)